### PR TITLE
Prune external Github entry from sitemap

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -11,8 +11,4 @@
     <loc>https://www.kismulet.org/source.html</loc>
     <priority>0.5</priority>
   </url>
-  <url>
-    <loc>https://github.com/sol-kismulet/kismulet.org</loc>
-    <priority>0.3</priority>
-  </url>
 </urlset>


### PR DESCRIPTION
## Summary
- remove the github.com link from `sitemap.xml` so that all URLs fall under the `www.kismulet.org` domain

## Testing
- `git status --short`
