### PR TITLE
Fix mobile text cutoff on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,11 +38,12 @@
       background-color: #ffffff;
       color: #111111;
       font-family: Georgia, serif;
+      margin: 0;
+      padding: 4vh 1rem;
       display: flex;
       justify-content: center;
-      align-items: center;
-      height: 100vh;
-      margin: 0;
+      align-items: flex-start;
+      min-height: 100vh;
     }
 
     .keystone-text {


### PR DESCRIPTION
## Summary
- ensure the body on `index.html` has padding and uses `min-height`
- align the main text container to the top so opening lines remain visible on mobile

## Testing
- `grep -n "100vh" index.html`